### PR TITLE
Dynamic kwargs generation as part of the recipe

### DIFF
--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -434,8 +434,8 @@ def dynamic_kwarg_generation(
         len(pd.date_range(format_date(a[0]), format_date(a[1]), freq="1MS"))
         for a in dates
     ]
-    print("Size per file: {filesizes}")
-    print("Inferred timesteps per file: {timesteps}")
+    print(f"Size per file: {filesizes}")
+    print(f"Inferred timesteps per file: {timesteps}")
     element_sizes = [size / n_t for size, n_t in zip(filesizes, timesteps)]
 
     target_chunks = {

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -348,6 +348,7 @@ def dynamic_kwarg_generation(
         Dictionary containing keyword arguments that can be passed to `XarrayZarrRecipe`
 
     """
+    print("====== Dynamically Getting Kwargs =======")
     # TODO, I query the API in multiple places. Need to refactor something robust (which might try different urls?)
 
     url = "https://esgf-node.llnl.gov/esg-search/search"

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -348,7 +348,7 @@ def dynamic_kwarg_generation(
         Dictionary containing keyword arguments that can be passed to `XarrayZarrRecipe`
 
     """
-    print("====== Dynamically Getting Kwargs =======")
+    print(f"====== Generate kwargs for {iid} =======")
     # TODO, I query the API in multiple places. Need to refactor something robust (which might try different urls?)
 
     url = "https://esgf-node.llnl.gov/esg-search/search"

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -434,6 +434,8 @@ def dynamic_kwarg_generation(
         len(pd.date_range(format_date(a[0]), format_date(a[1]), freq="1MS"))
         for a in dates
     ]
+    print("Size per file: {filesizes}")
+    print("Inferred timesteps per file: {timesteps}")
     element_sizes = [size / n_t for size, n_t in zip(filesizes, timesteps)]
 
     target_chunks = {

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -498,7 +498,6 @@ allowed_divisors = {
 ## Recipe Generation
 iids = [
     "CMIP6.CMIP.CCCma.CanESM5.historical.r1i1p1f1.Omon.zos.gn.v20190429",
-    "CMIP6.CMIP.CCCma.CanESM5.historical.r1i1p1f1.Omon.so.gn.v20190429",
 ]
 inputs = {iid: dynamic_kwarg_generation(iid) for iid in iids}
 


### PR DESCRIPTION
This PR reflects work that @cisaacstern and I did together a few days ago + plus some additional work I finished today. 

In general this PR enables us to dynamically generate values for the required input kwargs: `target_chunks` and `subset_inputs`, which vary widely across the datasets in the CMIP6 archive. This will hopefully enable us to scale this recipe to a larger number of instance ids, which would otherwise present a tremendous burden in terms of maintenance.

The basic logic starts from a list of 'allowed' chunksizes, to ensure that we do not chunk too 'odd', and if possible maintain full years, or multiples of 5 years etc. Currently this is only added for monthly resolution (but we can add others later easily, which will be required for e.g. the daily data in #5 ).

We then pull information of the ESGF API for any given instance id to determine the number of timesteps (from the daterange given in the filename) and the size for each file. Consequently we try to maximize the chunksize to get as close as possible with the given constraints to a target chunksize of 150MB (but never larger!) and designate the chunksize value as `target_chunk` kwarg.

We apply a similar logic to determine into how many parts we need to divide the input to have an input size <500MB, and parse that into the `subset_inputs` kwarg.

